### PR TITLE
Update to Paranamer 2.8 to get Java 8 Fix

### DIFF
--- a/pico/pom.xml
+++ b/pico/pom.xml
@@ -66,7 +66,7 @@
 			<dependency>
 				<groupId>com.thoughtworks.paranamer</groupId>
 				<artifactId>paranamer</artifactId>
-				<version>2.5.1</version>
+				<version>2.8</version>
 				<optional>true</optional>
 			</dependency>
 			<!-- For proxy -->
@@ -200,7 +200,7 @@
 				<plugin>
 					<groupId>com.thoughtworks.paranamer</groupId>
 					<artifactId>paranamer-maven-plugin</artifactId>
-					<version>2.5.1</version>
+					<version>2.8</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Please pull and release a PicoContainer2 where name binding works with Java 8.